### PR TITLE
Enable to use S3 native state locking

### DIFF
--- a/iam_policy_terraform_state.tf
+++ b/iam_policy_terraform_state.tf
@@ -27,3 +27,16 @@ data "aws_iam_policy_document" "put_terraform_state" {
     actions   = ["s3:PutObject"]
   }
 }
+
+data "aws_iam_policy_document" "lock_terraform_state" {
+  statement {
+    resources = ["arn:aws:s3:::${var.s3_bucket_terraform_state_name}/*.tflock"]
+    actions   = ["s3:PutObject", "s3:DeleteObject"]
+  }
+}
+
+resource "aws_iam_policy" "lock_terraform_state" {
+  count  = var.s3_bucket_terraform_state_name == "" ? 0 : 1
+  name   = "GitHubActions_Terraform_${var.name}_lock_terraform_state"
+  policy = data.aws_iam_policy_document.lock_terraform_state.json
+}

--- a/iam_role_terraform_apply.tf
+++ b/iam_role_terraform_apply.tf
@@ -16,3 +16,9 @@ resource "aws_iam_role_policy_attachment" "terraform_apply_put_terraform_state" 
   role       = aws_iam_role.terraform_apply.name
   policy_arn = aws_iam_policy.put_terraform_state[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "terraform_apply_lock_terraform_state" {
+  count      = var.s3_bucket_terraform_state_name == "" ? 0 : 1
+  role       = aws_iam_role.terraform_apply.name
+  policy_arn = aws_iam_policy.lock_terraform_state[0].arn
+}

--- a/iam_role_terraform_plan.tf
+++ b/iam_role_terraform_plan.tf
@@ -11,3 +11,10 @@ resource "aws_iam_role_policy_attachment" "terraform_plan_read_terraform_state" 
   role       = aws_iam_role.terraform_plan.name
   policy_arn = aws_iam_policy.read_terraform_state[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "terraform_plan_lock_terraform_state" {
+  count = var.s3_bucket_terraform_state_name == "" ? 0 : 1
+
+  role       = aws_iam_role.terraform_plan.name
+  policy_arn = aws_iam_policy.lock_terraform_state[0].arn
+}


### PR DESCRIPTION
* We can use S3 native state locking since [terraform v1.10](https://github.com/hashicorp/terraform/releases/tag/v1.10.0)
* In order to use native lock in plan and apply, it is necessary to be able to Put/Delete the <statefile>.tflock file in each policy.