### PR TITLE
fix: fix the permission for state locking from IAM Role for tfmigrate plan

### DIFF
--- a/iam_role_tfmigrate_plan.tf
+++ b/iam_role_tfmigrate_plan.tf
@@ -16,10 +16,3 @@ resource "aws_iam_role_policy_attachment" "tfmigrate_plan_read_terraform_state" 
   role       = aws_iam_role.tfmigrate_plan.name
   policy_arn = aws_iam_policy.read_terraform_state[0].arn
 }
-
-resource "aws_iam_role_policy_attachment" "tfmigrate_plan_lock_terraform_state" {
-  count = var.s3_bucket_terraform_state_name == "" ? 0 : 1
-
-  role       = aws_iam_role.tfmigrate_plan.name
-  policy_arn = aws_iam_policy.lock_terraform_state[0].arn
-}


### PR DESCRIPTION
tfmigrate plan doesn't need this permission