### PR TITLE
feat: support S3 Buckets encrypted with customer managed keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,27 @@ module "aws" {
 }
 ```
 
-These variables are lists rather than strings so that they can accept ARNs of KMS Keys created in
-the same plan, whose values are unknown at plan time.
+These variables are lists rather than strings so that several KMS Keys can be granted, for instance
+while migrating from one KMS Key to another.
+
+Lists also keep `terraform plan` readable when a KMS Key is created in the same plan and its ARN is
+unknown at plan time. `length()` of a list is known even if its elements are unknown, so the
+statements are still rendered in the plan:
+
+```
+      + statement {
+          + actions   = [
+              + "kms:Decrypt",
+            ]
+          + resources = [
+              + (known after apply),
+            ]
+        }
+```
+
+With a string and `var.foo == ""`, the condition itself would be unknown, so Terraform would defer
+the whole `aws_iam_policy_document` to apply time and the policy would be shown as
+`(known after apply)`, hiding which permissions are granted.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -40,17 +40,46 @@ resource "aws_iam_role_policy_attachment" "tfmigrate_apply_readonly" {
 }
 ```
 
+## S3 Buckets encrypted with customer managed keys
+
+If S3 Buckets are encrypted with customer managed keys (SSE-KMS), IAM Roles need permissions of the
+KMS Keys in addition to the permissions of the buckets. Otherwise `terraform init` fails:
+
+```
+Error: Error refreshing state: Unable to access object "<key>" in S3 bucket "<bucket>": operation error S3: GetObject, https response error StatusCode: 403, api error AccessDenied: User: <IAM Role> is not authorized to perform: kms:Decrypt on resource: <KMS Key> because no identity-based policy allows the kms:Decrypt action
+```
+
+Set the ARNs of the KMS Keys, then the module grants `kms:Decrypt` and `kms:GenerateDataKey` to the
+IAM Roles which need them:
+
+```tf
+module "aws" {
+  source = "github.com/suzuki-shunsuke/terraform-aws-tfaction"
+
+  name                                     = "AWS"
+  repo                                     = "suzuki-shunsuke/tfaction-example"
+  main_branch                              = "main"
+  s3_bucket_tfmigrate_history_name         = aws_s3_bucket.tfmigrate_history.id
+  s3_bucket_terraform_state_name           = aws_s3_bucket.terraform_state.id
+  s3_bucket_tfmigrate_history_kms_key_arns = [aws_kms_key.tfmigrate_history.arn]
+  s3_bucket_terraform_state_kms_key_arns   = [aws_kms_key.terraform_state.arn]
+}
+```
+
+These variables are lists rather than strings so that they can accept ARNs of KMS Keys created in
+the same plan, whose values are unknown at plan time.
+
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63 |
 
 ## Modules
@@ -60,7 +89,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.lock_terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.put_terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -81,7 +110,6 @@ No modules.
 | [aws_iam_role_policy_attachment.tfmigrate_apply_put_tfmigrate_history](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tfmigrate_apply_read_terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tfmigrate_apply_read_tfmigrate_history](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.tfmigrate_plan_lock_terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tfmigrate_plan_read_terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tfmigrate_plan_read_tfmigrate_history](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -96,20 +124,22 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_assume_role_policy_main_conditions"></a> [assume\_role\_policy\_main\_conditions](#input\_assume\_role\_policy\_main\_conditions) | n/a | <pre>list(object({<br/>    test     = string<br/>    variable = string<br/>    values   = list(string)<br/>  }))</pre> | `null` | no |
 | <a name="input_assume_role_policy_pr_conditions"></a> [assume\_role\_policy\_pr\_conditions](#input\_assume\_role\_policy\_pr\_conditions) | n/a | <pre>list(object({<br/>    test     = string<br/>    variable = string<br/>    values   = list(string)<br/>  }))</pre> | `null` | no |
 | <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | n/a | `bool` | `false` | no |
 | <a name="input_main_branch"></a> [main\_branch](#input\_main\_branch) | n/a | `string` | `"main"` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_repo"></a> [repo](#input\_repo) | n/a | `string` | n/a | yes |
+| <a name="input_s3_bucket_terraform_state_kms_key_arns"></a> [s3\_bucket\_terraform\_state\_kms\_key\_arns](#input\_s3\_bucket\_terraform\_state\_kms\_key\_arns) | ARNs of KMS Keys encrypting the S3 Bucket for Terraform State. If the bucket is encrypted with customer managed keys, you have to set this variable so that IAM Roles can read and write Terraform State. | `list(string)` | `[]` | no |
 | <a name="input_s3_bucket_terraform_state_name"></a> [s3\_bucket\_terraform\_state\_name](#input\_s3\_bucket\_terraform\_state\_name) | n/a | `string` | `""` | no |
+| <a name="input_s3_bucket_tfmigrate_history_kms_key_arns"></a> [s3\_bucket\_tfmigrate\_history\_kms\_key\_arns](#input\_s3\_bucket\_tfmigrate\_history\_kms\_key\_arns) | ARNs of KMS Keys encrypting the S3 Bucket for tfmigrate history. If the bucket is encrypted with customer managed keys, you have to set this variable so that IAM Roles can read and write tfmigrate history. | `list(string)` | `[]` | no |
 | <a name="input_s3_bucket_tfmigrate_history_name"></a> [s3\_bucket\_tfmigrate\_history\_name](#input\_s3\_bucket\_tfmigrate\_history\_name) | n/a | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_aws_iam_role_terraform_apply_arn"></a> [aws\_iam\_role\_terraform\_apply\_arn](#output\_aws\_iam\_role\_terraform\_apply\_arn) | AWS IAM Role ARN for terraform apply |
 | <a name="output_aws_iam_role_terraform_apply_name"></a> [aws\_iam\_role\_terraform\_apply\_name](#output\_aws\_iam\_role\_terraform\_apply\_name) | AWS IAM Role name for terraform apply |
 | <a name="output_aws_iam_role_terraform_plan_arn"></a> [aws\_iam\_role\_terraform\_plan\_arn](#output\_aws\_iam\_role\_terraform\_plan\_arn) | AWS IAM Role ARN for terraform plan |

--- a/README.md
+++ b/README.md
@@ -67,26 +67,11 @@ module "aws" {
 ```
 
 These variables are lists rather than strings so that several KMS Keys can be granted, for instance
-while migrating from one KMS Key to another.
+while migrating from one KMS Key to another, where objects encrypted with the old key still have to
+be decrypted.
 
-Lists also keep `terraform plan` readable when a KMS Key is created in the same plan and its ARN is
-unknown at plan time. `length()` of a list is known even if its elements are unknown, so the
-statements are still rendered in the plan:
-
-```
-      + statement {
-          + actions   = [
-              + "kms:Decrypt",
-            ]
-          + resources = [
-              + (known after apply),
-            ]
-        }
-```
-
-With a string and `var.foo == ""`, the condition itself would be unknown, so Terraform would defer
-the whole `aws_iam_policy_document` to apply time and the policy would be shown as
-`(known after apply)`, hiding which permissions are granted.
+ARNs of KMS Keys created in the same plan can be passed too, though the policies are shown as
+`(known after apply)` in the plan then.
 
 ## Requirements
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -67,23 +67,8 @@ module "aws" {
 ```
 
 These variables are lists rather than strings so that several KMS Keys can be granted, for instance
-while migrating from one KMS Key to another.
+while migrating from one KMS Key to another, where objects encrypted with the old key still have to
+be decrypted.
 
-Lists also keep `terraform plan` readable when a KMS Key is created in the same plan and its ARN is
-unknown at plan time. `length()` of a list is known even if its elements are unknown, so the
-statements are still rendered in the plan:
-
-```
-      + statement {
-          + actions   = [
-              + "kms:Decrypt",
-            ]
-          + resources = [
-              + (known after apply),
-            ]
-        }
-```
-
-With a string and `var.foo == ""`, the condition itself would be unknown, so Terraform would defer
-the whole `aws_iam_policy_document` to apply time and the policy would be shown as
-`(known after apply)`, hiding which permissions are granted.
+ARNs of KMS Keys created in the same plan can be passed too, though the policies are shown as
+`(known after apply)` in the plan then.

--- a/docs/header.md
+++ b/docs/header.md
@@ -39,3 +39,32 @@ resource "aws_iam_role_policy_attachment" "tfmigrate_apply_readonly" {
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 ```
+
+## S3 Buckets encrypted with customer managed keys
+
+If S3 Buckets are encrypted with customer managed keys (SSE-KMS), IAM Roles need permissions of the
+KMS Keys in addition to the permissions of the buckets. Otherwise `terraform init` fails:
+
+```
+Error: Error refreshing state: Unable to access object "<key>" in S3 bucket "<bucket>": operation error S3: GetObject, https response error StatusCode: 403, api error AccessDenied: User: <IAM Role> is not authorized to perform: kms:Decrypt on resource: <KMS Key> because no identity-based policy allows the kms:Decrypt action
+```
+
+Set the ARNs of the KMS Keys, then the module grants `kms:Decrypt` and `kms:GenerateDataKey` to the
+IAM Roles which need them:
+
+```tf
+module "aws" {
+  source = "github.com/suzuki-shunsuke/terraform-aws-tfaction"
+
+  name                                     = "AWS"
+  repo                                     = "suzuki-shunsuke/tfaction-example"
+  main_branch                              = "main"
+  s3_bucket_tfmigrate_history_name         = aws_s3_bucket.tfmigrate_history.id
+  s3_bucket_terraform_state_name           = aws_s3_bucket.terraform_state.id
+  s3_bucket_tfmigrate_history_kms_key_arns = [aws_kms_key.tfmigrate_history.arn]
+  s3_bucket_terraform_state_kms_key_arns   = [aws_kms_key.terraform_state.arn]
+}
+```
+
+These variables are lists rather than strings so that they can accept ARNs of KMS Keys created in
+the same plan, whose values are unknown at plan time.

--- a/docs/header.md
+++ b/docs/header.md
@@ -66,5 +66,24 @@ module "aws" {
 }
 ```
 
-These variables are lists rather than strings so that they can accept ARNs of KMS Keys created in
-the same plan, whose values are unknown at plan time.
+These variables are lists rather than strings so that several KMS Keys can be granted, for instance
+while migrating from one KMS Key to another.
+
+Lists also keep `terraform plan` readable when a KMS Key is created in the same plan and its ARN is
+unknown at plan time. `length()` of a list is known even if its elements are unknown, so the
+statements are still rendered in the plan:
+
+```
+      + statement {
+          + actions   = [
+              + "kms:Decrypt",
+            ]
+          + resources = [
+              + (known after apply),
+            ]
+        }
+```
+
+With a string and `var.foo == ""`, the condition itself would be unknown, so Terraform would defer
+the whole `aws_iam_policy_document` to apply time and the policy would be shown as
+`(known after apply)`, hiding which permissions are granted.

--- a/iam_policy_terraform_state.tf
+++ b/iam_policy_terraform_state.tf
@@ -13,6 +13,15 @@ data "aws_iam_policy_document" "read_terraform_state" {
     resources = ["arn:aws:s3:::${var.s3_bucket_terraform_state_name}"]
     actions   = ["s3:ListBucket"]
   }
+  # s3:GetObject requires kms:Decrypt if the bucket is encrypted with customer managed keys.
+  # This policy is attached to all IAM Roles reading Terraform State, so they can decrypt it.
+  dynamic "statement" {
+    for_each = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+    content {
+      resources = var.s3_bucket_terraform_state_kms_key_arns
+      actions   = ["kms:Decrypt"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "put_terraform_state" {
@@ -26,12 +35,31 @@ data "aws_iam_policy_document" "put_terraform_state" {
     resources = ["arn:aws:s3:::${var.s3_bucket_terraform_state_name}/*"]
     actions   = ["s3:PutObject"]
   }
+  # s3:PutObject requires kms:GenerateDataKey if the bucket is encrypted with customer managed keys.
+  # kms:Decrypt is granted by the policy read_terraform_state, which is attached to all IAM Roles
+  # writing Terraform State too.
+  dynamic "statement" {
+    for_each = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+    content {
+      resources = var.s3_bucket_terraform_state_kms_key_arns
+      actions   = ["kms:GenerateDataKey"]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "lock_terraform_state" {
   statement {
     resources = ["arn:aws:s3:::${var.s3_bucket_terraform_state_name}/*.tflock"]
     actions   = ["s3:PutObject", "s3:DeleteObject"]
+  }
+  # Lock files are encrypted as well as Terraform State, so creating them requires
+  # kms:GenerateDataKey. This is needed by terraform plan, which doesn't put Terraform State.
+  dynamic "statement" {
+    for_each = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+    content {
+      resources = var.s3_bucket_terraform_state_kms_key_arns
+      actions   = ["kms:GenerateDataKey"]
+    }
   }
 }
 

--- a/iam_policy_terraform_state.tf
+++ b/iam_policy_terraform_state.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "read_terraform_state" {
   # s3:GetObject requires kms:Decrypt if the bucket is encrypted with customer managed keys.
   # This policy is attached to all IAM Roles reading Terraform State, so they can decrypt it.
   dynamic "statement" {
-    for_each = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+    for_each = local.terraform_state_kms
     content {
       resources = var.s3_bucket_terraform_state_kms_key_arns
       actions   = ["kms:Decrypt"]
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "put_terraform_state" {
   # kms:Decrypt is granted by the policy read_terraform_state, which is attached to all IAM Roles
   # writing Terraform State too.
   dynamic "statement" {
-    for_each = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+    for_each = local.terraform_state_kms
     content {
       resources = var.s3_bucket_terraform_state_kms_key_arns
       actions   = ["kms:GenerateDataKey"]
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "lock_terraform_state" {
   # Lock files are encrypted as well as Terraform State, so creating them requires
   # kms:GenerateDataKey. This is needed by terraform plan, which doesn't put Terraform State.
   dynamic "statement" {
-    for_each = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+    for_each = local.terraform_state_kms
     content {
       resources = var.s3_bucket_terraform_state_kms_key_arns
       actions   = ["kms:GenerateDataKey"]

--- a/iam_policy_tfmigrate_history.tf
+++ b/iam_policy_tfmigrate_history.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "read_tfmigrate_history" {
   # s3:GetObject requires kms:Decrypt if the bucket is encrypted with customer managed keys.
   # This policy is attached to all IAM Roles reading tfmigrate history, so they can decrypt it.
   dynamic "statement" {
-    for_each = length(var.s3_bucket_tfmigrate_history_kms_key_arns) == 0 ? [] : [1]
+    for_each = local.tfmigrate_history_kms
     content {
       resources = var.s3_bucket_tfmigrate_history_kms_key_arns
       actions   = ["kms:Decrypt"]
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "put_tfmigrate_history" {
   # kms:Decrypt is granted by the policy read_tfmigrate_history, which is attached to all IAM Roles
   # writing tfmigrate history too.
   dynamic "statement" {
-    for_each = length(var.s3_bucket_tfmigrate_history_kms_key_arns) == 0 ? [] : [1]
+    for_each = local.tfmigrate_history_kms
     content {
       resources = var.s3_bucket_tfmigrate_history_kms_key_arns
       actions   = ["kms:GenerateDataKey"]

--- a/iam_policy_tfmigrate_history.tf
+++ b/iam_policy_tfmigrate_history.tf
@@ -12,6 +12,15 @@ data "aws_iam_policy_document" "read_tfmigrate_history" {
     resources = ["arn:aws:s3:::${var.s3_bucket_tfmigrate_history_name}"]
     actions   = ["s3:ListBucket"]
   }
+  # s3:GetObject requires kms:Decrypt if the bucket is encrypted with customer managed keys.
+  # This policy is attached to all IAM Roles reading tfmigrate history, so they can decrypt it.
+  dynamic "statement" {
+    for_each = length(var.s3_bucket_tfmigrate_history_kms_key_arns) == 0 ? [] : [1]
+    content {
+      resources = var.s3_bucket_tfmigrate_history_kms_key_arns
+      actions   = ["kms:Decrypt"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "put_tfmigrate_history" {
@@ -23,5 +32,15 @@ data "aws_iam_policy_document" "put_tfmigrate_history" {
   statement {
     resources = ["arn:aws:s3:::${var.s3_bucket_tfmigrate_history_name}/*"]
     actions   = ["s3:PutObject"]
+  }
+  # s3:PutObject requires kms:GenerateDataKey if the bucket is encrypted with customer managed keys.
+  # kms:Decrypt is granted by the policy read_tfmigrate_history, which is attached to all IAM Roles
+  # writing tfmigrate history too.
+  dynamic "statement" {
+    for_each = length(var.s3_bucket_tfmigrate_history_kms_key_arns) == 0 ? [] : [1]
+    content {
+      resources = var.s3_bucket_tfmigrate_history_kms_key_arns
+      actions   = ["kms:GenerateDataKey"]
+    }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,10 @@
 locals {
+  # `for_each` of the `dynamic` blocks granting permissions of the KMS Keys.
+  # `length()` is known at plan time even if the elements are unknown, such as ARNs of KMS Keys
+  # created in the same plan.
+  terraform_state_kms   = length(var.s3_bucket_terraform_state_kms_key_arns) == 0 ? [] : [1]
+  tfmigrate_history_kms = length(var.s3_bucket_tfmigrate_history_kms_key_arns) == 0 ? [] : [1]
+
   default_assume_role_policy_main_conditions = [
     {
       test     = "StringEquals"

--- a/variables.tf
+++ b/variables.tf
@@ -20,13 +20,9 @@ variable "s3_bucket_terraform_state_name" {
   default = ""
 }
 
-# These variables are lists rather than strings so that several KMS Keys can be granted,
-# for instance while migrating from one KMS Key to another.
-# Lists also keep `terraform plan` readable when a KMS Key is created in the same plan and its
-# ARN is unknown at plan time: `length()` of a list is known even if its elements are unknown,
-# so the statements are still rendered in the plan. With a string and `var.foo == ""`, the
-# condition itself would be unknown, so Terraform would defer the whole aws_iam_policy_document
-# to apply time and the policy would be shown as "(known after apply)".
+# These variables are lists rather than strings so that several KMS Keys can be granted, for
+# instance while migrating from one KMS Key to another, where objects encrypted with the old key
+# still have to be decrypted.
 variable "s3_bucket_terraform_state_kms_key_arns" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,13 @@ variable "s3_bucket_terraform_state_name" {
   default = ""
 }
 
-# These variables are lists rather than strings so that they can accept values which are
-# unknown at plan time, such as an ARN of a KMS Key created in the same plan.
-# `length()` of a list is known even if its elements are unknown, so `dynamic` blocks can be
-# conditioned on it, while `var.foo == ""` would fail with an unknown value.
+# These variables are lists rather than strings so that several KMS Keys can be granted,
+# for instance while migrating from one KMS Key to another.
+# Lists also keep `terraform plan` readable when a KMS Key is created in the same plan and its
+# ARN is unknown at plan time: `length()` of a list is known even if its elements are unknown,
+# so the statements are still rendered in the plan. With a string and `var.foo == ""`, the
+# condition itself would be unknown, so Terraform would defer the whole aws_iam_policy_document
+# to apply time and the policy would be shown as "(known after apply)".
 variable "s3_bucket_terraform_state_kms_key_arns" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,22 @@ variable "s3_bucket_terraform_state_name" {
   default = ""
 }
 
+# These variables are lists rather than strings so that they can accept values which are
+# unknown at plan time, such as an ARN of a KMS Key created in the same plan.
+# `length()` of a list is known even if its elements are unknown, so `dynamic` blocks can be
+# conditioned on it, while `var.foo == ""` would fail with an unknown value.
+variable "s3_bucket_terraform_state_kms_key_arns" {
+  type        = list(string)
+  default     = []
+  description = "ARNs of KMS Keys encrypting the S3 Bucket for Terraform State. If the bucket is encrypted with customer managed keys, you have to set this variable so that IAM Roles can read and write Terraform State."
+}
+
+variable "s3_bucket_tfmigrate_history_kms_key_arns" {
+  type        = list(string)
+  default     = []
+  description = "ARNs of KMS Keys encrypting the S3 Bucket for tfmigrate history. If the bucket is encrypted with customer managed keys, you have to set this variable so that IAM Roles can read and write tfmigrate history."
+}
+
 variable "create_oidc_provider" {
   type    = bool
   default = false


### PR DESCRIPTION
## Why

If the S3 Buckets for Terraform State and tfmigrate history are encrypted with customer managed keys (SSE-KMS), IAM Roles need permissions of the KMS Keys in addition to the permissions of the buckets. This module grants only the latter, so `terraform init` fails:

```
Error: Error refreshing state: Unable to access object "state/terraform/itg" in S3 bucket "xxx": operation error S3: GetObject, https response error StatusCode: 403, api error AccessDenied: User: arn:aws:sts::<account>:assumed-role/GitHubActions_Terraform_AWS_terraform_plan/xxx is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:ap-northeast-1:<account>:key/xxx because no identity-based policy allows the kms:Decrypt action
```

Every user has to write the same policy by hand outside the module, even though the module already owns the S3 permissions for the same buckets.

## What

Add two variables:

- `s3_bucket_terraform_state_kms_key_arns`
- `s3_bucket_tfmigrate_history_kms_key_arns`

The KMS statements are added to the existing policies rather than as new policies, so IAM Roles get exactly the permissions they need and the number of attached policies doesn't grow (IAM allows only 10 managed policies per Role):

| Policy | Added action | Why |
| --- | --- | --- |
| `read_terraform_state` / `read_tfmigrate_history` | `kms:Decrypt` | `s3:GetObject` of encrypted objects |
| `put_terraform_state` / `put_tfmigrate_history` | `kms:GenerateDataKey` | `s3:PutObject` of encrypted objects |
| `lock_terraform_state` | `kms:GenerateDataKey` | `terraform plan` creates `*.tflock` but doesn't put Terraform State |

The default is `[]`, so nothing changes unless the variables are set.

### Why lists instead of strings

So that several KMS Keys can be granted, for instance while migrating from one KMS Key to another, where objects encrypted with the old key still have to be decrypted.

ARNs of KMS Keys created in the same plan can be passed too. This doesn't fail the plan: an unknown value in a `dynamic` block's `for_each` is deferred, not rejected (only `count` and `for_each` of a resource fail, because they decide how many instances to create). Note that the policies are shown as `(known after apply)` in the plan then, because `aws_iam_policy.policy` is a single JSON string and one unknown element makes the whole string unknown. That is the same with a string variable, so it is not a reason to choose either shape.

## Test

Planned a root module which passes an ARN of a KMS Key created in the same plan (i.e. unknown at plan time):

- With the variables set: `Plan: 22 to add`, and the 5 policy documents got the KMS statements with `resources = [(known after apply)]` — 2 `kms:Decrypt`, 3 `kms:GenerateDataKey`.
- Without the variables (default `[]`): `Plan: 22 to add`, 0 KMS statements. No change from the current behaviour.
- The plan is identical before and after extracting the conditions to local values.

`terraform validate` passes.

## Note

`README.md` is regenerated with the pinned terraform-docs v0.24.0. Besides the new inputs, this drops a stale row (`aws_iam_role_policy_attachment.tfmigrate_plan_lock_terraform_state`, removed in #267) and reformats the table separators, since the README hadn't been regenerated since then.
